### PR TITLE
Add dependencies to `ExifFormat`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     ),
     .target(
       name: "ExifFormat",
-      dependencies: [],
+      dependencies: ["exif", "iptc"],
       path: "Sources/ExifFormat"
     ),
     .target(


### PR DESCRIPTION
This should provide a fix for #2. This worked for me when using the package locally. I ended up not using this library since `libexif` doesn't support RAW images, but hopefully this helps some other folks 😁 