### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ImageIO/CoreGraphics).
 On Ubuntu/Debian based Linux:
 
 ```bash
-apt install -y libiptc-data libexif-dev libiptcdata0-dev
+apt install -y libiptcdata-dev libexif-dev libiptcdata0-dev
 ```
 
 On macOS using brew:


### PR DESCRIPTION
On Ubuntu 20.04, I wasn't able to install `libiptc-data` because this package is no where to be found. Instead, `libiptcdata-dev` is available and works well.