### PR TITLE
Fix compile errors on Swift 6.3

### DIFF
--- a/Sources/SwiftExif/Exif.swift
+++ b/Sources/SwiftExif/Exif.swift
@@ -138,6 +138,7 @@ extension ExifEntry {
   mutating func value() -> String {
 
     let value = UnsafeMutablePointer<Int8>.allocate(capacity: 256)
+    defer { value.deallocate() }
     exif_entry_get_value(
       &self,
       value,
@@ -151,6 +152,7 @@ extension ExifEntry {
 
   mutating func rawValue() -> String? {
     let value = UnsafeMutablePointer<Int8>.allocate(capacity: 256)
+    defer { value.deallocate() }
     exif_entry_format_value(
       &self,
       value,

--- a/Sources/SwiftExif/Iptc.swift
+++ b/Sources/SwiftExif/Iptc.swift
@@ -67,6 +67,7 @@ extension IptcData {
 extension IptcDataSet {
   mutating func value() -> String {
     let value = UnsafeMutablePointer<Int8>.allocate(capacity: 256)
+    defer { value.deallocate() }
     iptc_dataset_get_as_str(&self, value, 256)
 
     let str = String(cString: value)
@@ -76,7 +77,7 @@ extension IptcDataSet {
   func tagTitle() -> String? {
     let value = iptc_tag_get_title(self.record, self.tag)
 
-    let str = String(cString: value)
+    let str = String(nullableCString: value)
     return str
   }
 
@@ -87,7 +88,7 @@ extension IptcDataSet {
   mutating func formatName() -> String? {
     let value = iptc_format_get_name(self.format())
 
-    let str = String(cString: value)
+    let str = String(nullableCString: value)
     return str
   }
 

--- a/Sources/SwiftExif/Util.swift
+++ b/Sources/SwiftExif/Util.swift
@@ -1,22 +1,22 @@
 extension String {
-  init?(cString: UnsafeMutablePointer<Int8>?) {
-    guard let cString = cString else { return nil }
-    self = String(cString: cString)
+  init?(nullableCString: UnsafeMutablePointer<Int8>?) {
+    guard let nullableCString else { return nil }
+    self = String(cString: nullableCString)
   }
 
-  init?(cString: UnsafeMutablePointer<CUnsignedChar>?) {
-    guard let cString = cString else { return nil }
-    self = String(cString: cString)
+  init?(nullableCString: UnsafeMutablePointer<CUnsignedChar>?) {
+    guard let nullableCString else { return nil }
+    self = String(cString: nullableCString)
   }
 
-  init?(cString: Any) {
+  init?(nullableCString: Any) {
 
-    if let pointer = cString as? UnsafeMutablePointer<CChar> {
+    if let pointer = nullableCString as? UnsafeMutablePointer<CChar> {
       self = String(cString: pointer)
       return
     }
 
-    if let pointer = cString as? UnsafeMutablePointer<CUnsignedChar> {
+    if let pointer = nullableCString as? UnsafeMutablePointer<CUnsignedChar> {
       self = String(cString: pointer)
       return
     }

--- a/Tests/SwiftExifTests/SwiftExifTests.swift
+++ b/Tests/SwiftExifTests/SwiftExifTests.swift
@@ -1,13 +1,22 @@
 import XCTest
+import Foundation
 
 @testable import SwiftExif
 @testable import exif
 @testable import iptc
 
-let testImage = "Tests/test.jpg"
-let testImageSpecialCharacters = "Tests/test_special_chars.jpg"
-let testImagePhotosExport = "Tests/photos_export.jpg"
-let testImageOSXPhotosExifExport = "Tests/osxphotos_exif_export.jpg"
+private let testsDirectoryURL = URL(fileURLWithPath: #filePath)
+  .deletingLastPathComponent()
+  .deletingLastPathComponent()
+
+private func testImagePath(_ imageName: String) -> String {
+  testsDirectoryURL.appendingPathComponent(imageName).path
+}
+
+let testImage = testImagePath("test.jpg")
+let testImageSpecialCharacters = testImagePath("test_special_chars.jpg")
+let testImagePhotosExport = testImagePath("photos_export.jpg")
+let testImageOSXPhotosExifExport = testImagePath("osxphotos_exif_export.jpg")
 
 final class SwiftExifTests: XCTestCase {
   func test() {
@@ -18,14 +27,17 @@ final class SwiftExifTests: XCTestCase {
   }
 
   func testExifReadExifData() {
-    let rawUnsafeExifData = exif_data_new_from_file(testImage)
-    var exifData = ExifData.new(imagePath: testImage)
+    guard let rawUnsafeExifData = exif_data_new_from_file(testImage) else {
+      XCTFail("Cannot load EXIF data from image at path: \(testImage)")
+      return
+    }
+    guard var exifData = ExifData.new(imagePath: testImage) else {
+      XCTFail("Cannot create ExifData from image at path: \(testImage)")
+      return
+    }
 
-    XCTAssertNotNil(rawUnsafeExifData)
-    XCTAssertNotNil(exifData)
-
-    let contents = rawUnsafeExifData!.pointee.content()
-    let contents2 = exifData!.content()
+    let contents = rawUnsafeExifData.pointee.content()
+    let contents2 = exifData.content()
 
     XCTAssertEqual(contents.count, 5)
     XCTAssertEqual(contents2.count, 5)
@@ -149,24 +161,27 @@ final class SwiftExifTests: XCTestCase {
   }
 
   func testIptcReadIptcData() {
-    let rawUnsafeIptcData = iptc_data_new_from_jpeg(testImage)
-    let iptcData = IptcData.new(imagePath: testImage)
+    guard let rawUnsafeIptcData = iptc_data_new_from_jpeg(testImage) else {
+      XCTFail("Cannot load IPTC data from image at path: \(testImage)")
+      return
+    }
+    guard let iptcData = IptcData.new(imagePath: testImage) else {
+      XCTFail("Cannot create IptcData from image at path: \(testImage)")
+      return
+    }
 
-    XCTAssertNotNil(rawUnsafeIptcData)
-    XCTAssertNotNil(iptcData)
+    let datasets = rawUnsafeIptcData.pointee.datasets()
+    let datasets2 = iptcData.datasets()
 
-    let datasets = rawUnsafeIptcData!.pointee.datasets()
-    let datasets2 = iptcData!.datasets()
-
-    XCTAssertEqual(datasets.count, Int(rawUnsafeIptcData!.pointee.count))
-    XCTAssertEqual(datasets2.count, Int(iptcData!.count))
+    XCTAssertEqual(datasets.count, Int(rawUnsafeIptcData.pointee.count))
+    XCTAssertEqual(datasets2.count, Int(iptcData.count))
     XCTAssertEqual(datasets.count, datasets2.count)
 
-    let tuples = iptcData!.toTuples()
+    let tuples = iptcData.toTuples()
 
     XCTAssertEqual(tuples.count, datasets2.count)
 
-    let dict = iptcData!.toDict()
+    let dict = iptcData.toDict()
     XCTAssertEqual(dict.count, 13)
 
     XCTAssertEqual(dict["Coded Character Set"] as! String, "1b 25 47")
@@ -189,7 +204,7 @@ final class SwiftExifTests: XCTestCase {
         "Train", "YGT"
       ])
 
-    let keywords = iptcData!.keywords()
+    let keywords = iptcData.keywords()
     let keywordsFromDict = dict["Keywords"] as! [String]
 
     XCTAssertEqual(keywords.count, 8)


### PR DESCRIPTION
Three changes:
 - fixes for Swift 6.3
 - memory leaks
 - reading files in unit tests